### PR TITLE
fix: placement on pasting with `p` in visual mode

### DIFF
--- a/lua/karen-yank/keymaps.lua
+++ b/lua/karen-yank/keymaps.lua
@@ -55,7 +55,7 @@ function M.set_maps(config)
 	for key, desc in pairs(reg_keys.paste) do
 		if not config.on_paste.black_hole_default then return end
 
-		map("v", key, '"_d' .. key, { desc = desc .. " and Delete Selection" })
+		map("v", key, '"_dP', { desc = desc .. " and Delete Selection" })
 		map(
 			"v",
 			config.mappings.karen .. key,


### PR DESCRIPTION


This reverts commit 55c9271418b46e879d5bb7bf17e5ab38acdfd9f8.